### PR TITLE
fix: inheritance was broken

### DIFF
--- a/zip_operator_plugin.py
+++ b/zip_operator_plugin.py
@@ -36,6 +36,8 @@ class ZipOperator(BaseOperator):
         self.path_to_file_to_zip = path_to_file_to_zip
         self.path_to_save_zip = path_to_save_zip
 
+        super(ZipOperator, self).__init__(*args, **kwargs)
+
     def execute(self, context):
         logging.info("Executing ZipOperator.execute(context)")
 
@@ -103,6 +105,8 @@ class UnzipOperator(BaseOperator):
             *args, **kwargs):
         self.path_to_zip_file = path_to_zip_file
         self.path_to_unzip_contents = path_to_unzip_contents
+
+        super(UnzipOperator, self).__init__(*args, **kwargs)
 
     def execute(self, context):
         logging.info("Executing UnzipOperator.execute(context)")


### PR DESCRIPTION
added call to super constructor to resolve 'has no attribute task_id'
the plugin did not work anymore without this lines on composer-1.7.7-airflow-1.10.2